### PR TITLE
Update README.md - Simple Markdown corrections

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
-#concrete5 Theme Boilerplate#
+# concrete5 Theme Boilerplate
 A base to begin building your concrete5 theme.
 
 **This package is for concrete 5.7.1+ (also the upcoming version 8) for a < 5.6.x version see [here](https://github.com/olsgreen/concrete5-theme-boilerplate/tree/1.0).**
 
 Note that if you are not familiar with concrete, want to generate a packaged theme or just want to speed up development, you can fill in a form and [generate a customised theme boilerplate](https://c5labs.com/concrete5-boilerplate/concrete5-starter-theme) at c5labs.com. This will provide you with a customised theme or package zip that you can simply extract to your packages or theme directory without the need to update namespaces, handles, etc.
 
-##Installation##
+## Installation
 
 1. Copy the 'theme-boilerplate' folder to your concrete5 instances 'application/themes' folder.
 2. Rename the copied theme folder to your desired theme name.
@@ -15,10 +15,10 @@ Note that if you are not familiar with concrete, want to generate a packaged the
 6. Click on 'Return to Themes' in the lower left hand corner of your screen.
 7. You will see the new theme listed, click 'Activate' to apply the theme to your site.
 
-##Change Log##
+## Change Log
 
 See the releases [here](https://github.com/c5labs/theme-boilerplate/releases).
 
-##License##
+## License
 
 MIT (See included license file)


### PR DESCRIPTION
Headings - Missing space after hashes and un-needed hashes following.  Guessing it's copied from an old template.

Seems to be a meme with c5labs GitHub repos ;-P